### PR TITLE
Ensure directory for Unix domain socket exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,10 @@ updated. The default is `true`.
 
 ### `unix_domain_socket`
 
-Specify the unix domain socket file `procServ` will create for connections to
-the IOC shell. You can connect to the IOC shell using
-`nc -U <unix_domain_socket>`. The default is `/run/softioc/<ioc_name>.sock`.
+Specify the Unix domain socket file `procServ` will create for connections to
+the IOC shell. The file name has to be specified relative to the run-time
+directory (`/run`). You can connect to the IOC shell using
+`nc -U <unix_domain_socket>`. The default is `softioc-<ioc_name>/procServ.sock`.
 
 Note that the unix domain socket will not be created if
 `enable_unix_domain_socket` is set to `false`.

--- a/manifests/ioc.pp
+++ b/manifests/ioc.pp
@@ -16,7 +16,7 @@ define epics_softioc::ioc(
   Boolean                                $enable_console_port         = true,
   Integer[1, 65535]                      $console_port                = 4051,
   Boolean                                $enable_unix_domain_socket   = true,
-  String                                 $unix_domain_socket          = "unix:/run/softioc/${name}.sock",
+  String                                 $unix_domain_socket          = "softioc-${name}/procServ.sock",
   Integer                                $coresize                    = 10000000,
   Array[String]                          $cfg_append                  = [],
   Hash[String, String, default, default] $env_vars                    = {},

--- a/manifests/unix_domain_socket.pp
+++ b/manifests/unix_domain_socket.pp
@@ -5,11 +5,4 @@ class epics_softioc::unix_domain_socket() {
   package { 'netcat-openbsd':
     ensure => lookup('epics_softioc::software::ensure_netcat-openbsd', String, 'first', 'latest'),
   }
-
-  file { '/run/softioc':
-    ensure => directory,
-    owner  => 'root',
-    group  => 'softioc',
-    mode   => '0775',
-  }
 }

--- a/templates/etc/systemd/system/ioc.service
+++ b/templates/etc/systemd/system/ioc.service
@@ -9,9 +9,12 @@ RequiresMountsFor=<%= @systemd_requires_mounts_for.join(' ') %>
 Environment="<%= key %>=<%= val %>"
 <% end -%>
 EnvironmentFile=-/etc/iocs/<%= @name -%>/config
-ExecStart=/usr/bin/procServ --foreground --quiet --chdir=<%= @absbootdir -%> --ignore=^C^D^] --coresize=<%= @coresize -%> --restrict --logfile=<%= @procserv_log_file -%> --name <%= @name -%><% if @enable_console_port %> --port <%= @console_port -%><% end %><% if @enable_unix_domain_socket %> --port <%= @unix_domain_socket -%><% end %> <%= @absstartscript %>
+ExecStart=/usr/bin/procServ --foreground --quiet --chdir=<%= @absbootdir -%> --ignore=^C^D^] --coresize=<%= @coresize -%> --restrict --logfile=<%= @procserv_log_file -%> --name <%= @name -%><% if @enable_console_port %> --port <%= @console_port -%><% end %><% if @enable_unix_domain_socket %> --port unix:/run/<%= @unix_domain_socket -%><% end %> <%= @absstartscript %>
 Restart=always
 User=<%= @username %>
+<% if @enable_unix_domain_socket -%>
+RuntimeDirectory=<%= File.dirname(@unix_domain_socket) %>
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The previously used `/run/softioc` directory gets removed on system start. procServ doesn't  automatically create this subdirectory and fails to start. This means the IOC is down until Puppet fixes the issue during the first Puppet run after system boot.

Note: Updating to this version updates all IOC's unit files and thus causes the IOC to restart.